### PR TITLE
Windows support merge

### DIFF
--- a/lib/multicouch.js
+++ b/lib/multicouch.js
@@ -10,7 +10,7 @@ var ini = require("ini");
 
 function MultiCouch(args) {
   events.EventEmitter.call(this);
-  var prefix = args.prefix || process.platform === "win32" ? process.env["TEMP"] : "/tmp";
+  var prefix = args.prefix || (process.platform === "win32" ? process.env["TEMP"] : "/tmp");
   var win_ini, win_bin;
   if (process.platform === "win32") {
     win_bin = process.arch == "x64" ? 'C:\\Program Files (x86)\\Apache Software Foundation\\CouchDB\\bin\\erl.exe' : 'C:\\Program Files\\Apache Software Foundation\\CouchDB\\bin\\erl.exe';


### PR DESCRIPTION
Implements support for windows, including all options and commands. Not tested for breakage in *nix but would be incredibly surprised if any occurs. 
