### PR TITLE
check if COUCHDB_PATH env var exists and use relative paths for bin and default_ini

### DIFF
--- a/lib/multicouch.js
+++ b/lib/multicouch.js
@@ -23,9 +23,9 @@ function MultiCouch(args) {
     stderr_file: args.stderr_file || path.join(prefix,"couch.stderr"),
     stdout_file: args.stdout_file || path.join(prefix,"couch.stdout"),
     ini_file: args.ini_file || path.join(prefix,"couch.ini"),
-    default_sys_ini: args.default_sys_ini || system_couch.default_ini() || "/usr/local/etc/couchdb/default.ini",
+    default_sys_ini: args.default_sys_ini || system_couch.default_ini || "/usr/local/etc/couchdb/default.ini",
     pid_file: args.pid_file || prefix + "/couch.pid",
-    couchdb_path: args.couchdb_path || process.env.COUCHDB_PATH || win_bin || system_couch.bin(),
+    couchdb_path: args.couchdb_path || win_bin || system_couch.bin,
     respawn: args.respawn === undefined ? 5: args.respawn
   };
 
@@ -138,6 +138,13 @@ function MultiCouch(args) {
 var system_couch = function() {
   var bin = null;
   var default_ini = null
+  if (process.env.COUCHDB_PATH) {
+    var prefix = process.env.COUCHDB_PATH;
+    return {
+      bin: path.resolve(prefix, 'bin/couchdb'),
+      default_ini: path.resolve(prefix, 'etc/couchdb/default.ini')
+    };
+  }
   try {
     bin = which("couchdb");
     // to find `default.ini`, we need to take the following
@@ -148,7 +155,7 @@ var system_couch = function() {
     // `bin/`, e.g. `/usr/local/bin` and `/usr/local/etc`.
     // `/usr/bin` however usually pairs with `/etc`, so we
     // need to special-case that.
-    if(bin == '/usr/bin/couchdb') {
+    if(bin === '/usr/bin/couchdb') {
       default_ini = '/etc/couchdb/default.ini';
     } else {
       default_ini = path.resolve(path.dirname(bin), '../etc/couchdb/default.ini');
@@ -161,18 +168,11 @@ var system_couch = function() {
     default_ini = 'etc/couchdb/default.ini';
   }
   return {
-    bin: function() {
-      return bin;
-    },
-    default_ini: function() {
-      return default_ini;
-    }
-  }
+    bin: bin,
+    default_ini: default_ini
+  };
 }();
 
-
-system_couch.bin(); // -> string | throw new Exception("no couch bin found")
-system_couch.default_ini(); // string | undefined
 
 util.inherits(MultiCouch, events.EventEmitter);
 module.exports = MultiCouch;


### PR DESCRIPTION
This fixes my issues on Linux when using a custom build of couchdb (with db_updates)

See https://github.com/hoodiehq/hoodie-server/pull/168
