### PR TITLE
Work in progress: emit start event asynchronously

### DIFF
--- a/lib/multicouch.js
+++ b/lib/multicouch.js
@@ -105,7 +105,10 @@ function MultiCouch(args) {
         env: process.env
       });
     }
-    this.emit("start");
+
+    process.nextTick(function () {
+      this.emit("start");
+    }.bind(this));
   };
 
   this.stop = function() {

--- a/lib/multicouch.js
+++ b/lib/multicouch.js
@@ -126,7 +126,10 @@ function MultiCouch(args) {
           env: process.env
       });
     }
-    this.emit("stop");
+
+    process.nextTick(function () {
+      this.emit("stop");
+    }.bind(this));
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Launch multiple CouchDBs from the same installation.",
   "main": "lib/multicouch.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/nodeunit test"
   },
   "repository": "git://github.com/hoodiehq/node-multicouch.git",
   "author": "Jan Lehnardt",
@@ -17,6 +17,7 @@
     "shelljs": "~0.2.6"
   },
   "devDependencies": {
+    "nodeunit": "^0.8.6",
     "request": "^2.34.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "which": "1.x",
     "ini": "1.x",
     "shelljs": "~0.2.6"
+  },
+  "devDependencies": {
+    "request": "^2.34.0"
   }
 }

--- a/test/start-event.js
+++ b/test/start-event.js
@@ -2,21 +2,27 @@
 
 var MultiCouch = require('../lib/multicouch');
 
-exports['multicouch emits start event asynchronously'] = function (test) {
-  var couch;
+exports.tearDown = function (callback) {
+  this.couch.stop();
 
+  this.couch.once('stop', function () {
+    callback();
+  });
+};
+
+exports['multicouch emits start event asynchronously'] = function (test) {
   test.expect(0);
 
   function synchronousCatcher () {
     throw new Error('start event emitted synchronously');
   }
 
-  couch = new MultiCouch({});
-  couch.on('start', synchronousCatcher);
-  couch.start();
-  couch.removeListener('start', synchronousCatcher);
+  this.couch = new MultiCouch({});
+  this.couch.on('start', synchronousCatcher);
+  this.couch.start();
+  this.couch.removeListener('start', synchronousCatcher);
 
-  couch.on('start', function() {
+  this.couch.on('start', function() {
     test.done();
   });
 };

--- a/test/start-event.js
+++ b/test/start-event.js
@@ -1,0 +1,22 @@
+// Execute `nodeunit test` from `node-multicouch` directory to run this test.
+
+var MultiCouch = require('../lib/multicouch');
+
+exports['multicouch emits start event asynchronously'] = function (test) {
+  var couch;
+
+  test.expect(0);
+
+  function synchronousCatcher () {
+    throw new Error('start event emitted synchronously');
+  }
+
+  couch = new MultiCouch({});
+  couch.on('start', synchronousCatcher);
+  couch.start();
+  couch.removeListener('start', synchronousCatcher);
+
+  couch.on('start', function() {
+    test.done();
+  });
+};

--- a/test/start-event.js
+++ b/test/start-event.js
@@ -1,6 +1,7 @@
 // Execute `nodeunit test` from `node-multicouch` directory to run this test.
 
 var MultiCouch = require('../lib/multicouch');
+var request = require('request');
 
 exports.tearDown = function (callback) {
   if (!this.couch) {
@@ -52,6 +53,23 @@ exports['multicouch emits stop event asynchronously'] = function (test) {
     couch.removeListener('stop', synchronousCatcher);
 
     couch.on('stop', function() {
+      test.done();
+    });
+  });
+};
+
+exports['couchdb is ready for requests on start event'] = function (test) {
+  var couch;
+  var port = 12345;
+
+  test.expect(1);
+
+  this.couch = new MultiCouch({ port: port });
+  this.couch.start();
+
+  this.couch.on('start', function() {
+    request('http://localhost:' + port, function (err) {
+      test.equal(err, null);
       test.done();
     });
   });


### PR DESCRIPTION
This is work in progress intended to fix issue #4.

Lets start by adding failing test showing that `multicouch` emits start event synchronously.
