### PR TITLE
Ask couchdb the default.ini path

### DIFF
--- a/lib/multicouch.js
+++ b/lib/multicouch.js
@@ -147,19 +147,10 @@ var system_couch = function() {
   }
   try {
     bin = which("couchdb");
-    // to find `default.ini`, we need to take the following
-    // things into account:
-    // `couchdb` might live in `/usr/bin`, `/usr/local/bin` or
-    // in another `$prefix/bin dir. In all cases but `/usr/bin`,
-    // the corresponding `etc/` directory exists next to
-    // `bin/`, e.g. `/usr/local/bin` and `/usr/local/etc`.
-    // `/usr/bin` however usually pairs with `/etc`, so we
-    // need to special-case that.
-    if(bin === '/usr/bin/couchdb') {
-      default_ini = '/etc/couchdb/default.ini';
-    } else {
-      default_ini = path.resolve(path.dirname(bin), '../etc/couchdb/default.ini');
-    }
+    // Get the default.ini config from couchdb config file chain
+    default_ini = execSync("couchdb -c | grep default.ini | head -1", {
+      silent:true
+    }).output;
   } catch (e) {
     // couldn'd find one in PATH, maybe there is an
     // `Apache CouchDB.app` that we can use


### PR DESCRIPTION
Instead of applying various heuristics to guess `deafult.ini` file, we
can directly use the couchdb binary for figuring out the path.

Ref: https://github.com/hoodiehq/hoodie-server/issues/291
