### PR TITLE
Fix win_bin path for x86 and x64 architectures.

### DIFF
--- a/lib/multicouch.js
+++ b/lib/multicouch.js
@@ -14,7 +14,7 @@ function MultiCouch(args) {
   var prefix = args.prefix || (process.platform === "win32" ? process.env["TEMP"] : "/tmp");
   var win_ini, win_bin;
   if (process.platform === "win32") {
-    win_bin = 'C:\\Program Files (x86)\\Apache Software Foundation\\CouchDB\\bin\\erl.exe';
+    win_bin = process.arch == "x64" ? 'C:\\Program Files (x86)\\Apache Software Foundation\\CouchDB\\bin\\erl.exe' : 'C:\\Program Files\\Apache Software Foundation\\CouchDB\\bin\\erl.exe';
     if(!fs.existsSync(win_bin)) win_bin = undefined;
   }
 


### PR DESCRIPTION
The boolean expression on line 17 was in the wrong order.
On x64 based Windows installations CouchDB is found at the "Program Files (x86)", while it is in the regular "Program Files" on x86 based Windows installations.
